### PR TITLE
Adding support for multiple-entities in one request

### DIFF
--- a/src/devtools/panel.js
+++ b/src/devtools/panel.js
@@ -562,10 +562,14 @@ window.Omnibug = (() => {
      *
      * @param requestId
      */
-    function updateRedirectedEntries(requestId) {
+    function updateRedirectedEntries(requestId, multipleEntriesPerRequest) {
         let redirectedEntries = d.querySelectorAll(`.request[data-request-id="${requestId}"]`);
         redirectedEntries.forEach((entry) => {
-            entry.classList.add("redirected");
+            if (multipleEntriesPerRequest) {
+                entry.classList.add("multipled");
+            } else {
+                entry.classList.add("redirected");
+            }
         });
     }
 
@@ -630,7 +634,7 @@ window.Omnibug = (() => {
             body = createElement("div");
 
         // Update any redirected entries
-        updateRedirectedEntries(request.request.id);
+        updateRedirectedEntries(request.request.id, request.multipleEntriesPerRequest);
 
         // Setup parent details element
         if (settings.alwaysExpand) {
@@ -653,6 +657,16 @@ window.Omnibug = (() => {
                     "title": "This entry was redirected."
                 },
                 "children": [colTitleRedirectIcon]
+            }),
+            colTitleMultipleIcon = createElement("i", {
+                "classes": ["fas", "fa-table"]
+            }),
+            colTitleMultiple = createElement("small", {
+                "classes": ["multiple", "multiple-icon"],
+                "attributes": {
+                    "title": "This entry was part of a single request."
+                },
+                "children": [colTitleMultipleIcon]
             }),
             colAccount = createElement("div", {
                 "classes": ["column", "col-3", "col-lg-4", "col-md-4", "col-sm-5"]
@@ -680,7 +694,7 @@ window.Omnibug = (() => {
 
         let colTitleWrapper = createElement("div", {
             "classes": ["column", "col-3", "col-lg-4", "col-md-4", "col-sm-5"],
-            "children": [requestTypeEl, colTitleSpan, colTitleRedirect],
+            "children": [requestTypeEl, colTitleSpan, colTitleRedirect, colTitleMultiple],
             "attributes": {
                 "title": `${request.provider.name} ${requestTypeValue.value}`
             }

--- a/src/devtools/panel.scss
+++ b/src/devtools/panel.scss
@@ -157,8 +157,25 @@ nav.navbar {
 .request:not(.redirected) .redirect {
   display: none;
 }
+.request:not(.multipled) .multiple {
+  display: none;
+}
 .request.redirected {
   .redirect-icon {
+    margin-left: .5em;
+    color: $gray-color;
+  }
+  .request-note {
+    margin-top: 0.4rem;
+  }
+}
+.request.redirected:hover {
+  .redirect-icon {
+    color: $warning-color;
+  }
+}
+.request.multipled {
+  .multiple-icon {
     margin-left: .5em;
     color: $gray-color;
   }

--- a/src/eventPage.js
+++ b/src/eventPage.js
@@ -99,14 +99,23 @@
                 }
             }
 
-            // Parse the URL and join our request info to the parsed data
-            data = Object.assign(
-                data,
-                OmnibugProvider.parseUrl(data.request.url, data.request.postData)
-            );
+            let providerDataArray = OmnibugProvider.parseUrl(data.request.url, data.request.postData);
+            if (!Array.isArray(providerDataArray)) {
+                providerDataArray = [providerDataArray];
+            } else {
+                data.multipleEntriesPerRequest = true;
+            }
 
-            console.log("Matched URL, sending data to devtools", data);
-            tabs[details.tabId].port.postMessage(data);
+            providerDataArray.forEach(providerData => {
+                // Parse the URL and join our request info to the parsed data
+                let finalData = Object.assign(
+                    data,
+                    providerData
+                );
+                console.log("Matched URL, sending data to devtools", finalData);
+                tabs[details.tabId].port.postMessage(finalData);
+            });
+
         },
         { urls: ["<all_urls>"] },
         ["requestBody"]


### PR DESCRIPTION
There are some scenarios when a request contains multiple events, and you wanna visualize them separately in the panel.

This was exactly my need, therefore I added the support for this.

The implementation is simple, if `parseUrls` returns an array, we send multiple messages to the panel and treat them as fake-multiple requests. To avoid that this request is flagged as "redirect", I've also added a flag that should visualize this in the panel.

A simple implementation for a Provider would be this:


```js
parseUrl(rawUrl, postDataStr) {
        let url = new URL(rawUrl);
        const postData = JSON.parse(postDataStr);
        return postData.events.map(event => {
            const data = this.parseEvent(url, event);
            return {
                "provider": {
                    "name":    this.name,
                    "key":     this.key,
                    "type":    this.type,
                    "columns": this.columnMapping,
                    "groups":  this.groups
                },
                "data": data
            };
        });
    }
```

