### PR TITLE
updated Adobe Launch CN icon path

### DIFF
--- a/src/assets/styles/icons.scss
+++ b/src/assets/styles/icons.scss
@@ -8,6 +8,7 @@ $icons: (
     "Adobe Dynamic Tag Manager": $iconPath + "ADOBEDYNAMICTAGMANAGER16x16.png",
     "Adobe Heartbeat": $iconPath + "ADOBEHEARTBEAT16x16.png",
     "Adobe Launch": $iconPath + "ADOBELAUNCH16x16.png", 
+    "Adobe Launch China Node": $iconPath + "ADOBELAUNCH16x16.png", 
     "Adobe Target": $iconPath + "ADOBETARGET16x16.png",
     "AT Internet": $iconPath + "ATINTERNET16x16.png",
     "Bing Ads": $iconPath + "BINGADS16x16.png",


### PR DESCRIPTION
Just including the same icon path for the Adobe Launch China Node provider.