### PR TITLE
Added extra segment url for EU

### DIFF
--- a/src/providers/Segment.js
+++ b/src/providers/Segment.js
@@ -11,7 +11,7 @@ class SegmentProvider extends BaseProvider
     {
         super();
         this._key        = "SEGMENT";
-        this._pattern    = /api\.segment\.io\//;
+        this._pattern    = /(\.segmentapis\.com\/)|(api\.segment\.io\/)/;
         this._name       = "Segment";
         this._type       = "analytics";
     }


### PR DESCRIPTION
As per their documentationm, Segment has two possible URLs for their API, one in the US and one in the EU:

- https://segment.com/docs/guides/regional-segment/#server-side-and-project-sources

The extension currently supports only US one. This PR adds the EU one to the pattern so both are considered valid Segment URLs.