### PR TITLE
Add consent mode parameter for Google Ads and GA4

### DIFF
--- a/src/providers/GoogleAds.js
+++ b/src/providers/GoogleAds.js
@@ -63,6 +63,10 @@ class GoogleAdsProvider extends BaseProvider {
             "label": {
                 "name": "Conversion Label",
                 "group": "general"
+            },
+            "gcs": {
+                "name": "Consent Mode",
+                "group": "general"
             }
         };
     }

--- a/src/providers/GoogleAnalytics4.js
+++ b/src/providers/GoogleAnalytics4.js
@@ -369,6 +369,10 @@ class GoogleAnalytics4Provider extends BaseProvider
                 "name": "Display Features Enabled",
                 "group": "general"
             },
+            "gcs": {
+                "name": "Consent Mode",
+                "group": "general"
+            },
             "requestType": {
                 "hidden": true
             }


### PR DESCRIPTION
Adds the Google Consent Mode parameter `gcs` to the general group for Google Analytics 4 and Google Ads.

![image](https://github.com/user-attachments/assets/340fab20-9ed1-44de-9e8e-53df9f91e172)
